### PR TITLE
Check Formatting in CI Workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+ColumnLimit: 0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,5 +12,8 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v4.2.2
 
+      - name: Check Formatting
+        run: make format && git diff --exit-code HEAD
+
       - name: Build Project
         run: make --no-print-directory

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.clang-format
 !.git*
 
 puzzle-1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: test
+.PHONY: format test
+
+format:
+	@clang-format -i **/*.cpp
 
 test:
 	@make -C day-01


### PR DESCRIPTION
This pull request resolves #21 by modifying the `build` workflow to check for source code formatting. It also adds a new `format` target to the `Makefile` and introduces a new `.clang-format` file to specify the Clang Format configuration.