### PR TITLE
Fix Default Make Command Does Not Test Solutions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: format test
 
-format:
-	@clang-format -i **/*.cpp
-
 test:
 	@make -C day-01
 	@make -C day-02
 	@make -C day-03
 	@make -C day-04
+
+format:
+	@clang-format -i **/*.cpp


### PR DESCRIPTION
This pull request resolves #25 by moving the `test` target in the `Makefile` above all other targets, effectively making it the default target.