### PR TITLE
Integrate Lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-commit:
+  piped: true
+  jobs:
+    - name: fix formatting
+      run: clang-format -i {staged_files}
+      glob: "*.cpp"
+
+    - name: check diff
+      run: git diff --exit-code {staged_files}


### PR DESCRIPTION
This pull request resolves #108 by integrating [Lefthook](https://lefthook.dev/) into this project, allowing pre-commit hooks to be installed and executed on staged files.